### PR TITLE
Specify explicitly what 10 MB means, MB as compared to MiB. Not sure …

### DIFF
--- a/bip-0270.mediawiki
+++ b/bip-0270.mediawiki
@@ -273,6 +273,10 @@ specified in this spec is a candidate to convey information for extensions.
 
 ==Notes==
 
+Where message length limits are described in MB, or other units, they should be taken to
+be the SI form. Therefore 10MB means 10,000,000 bytes, and not 10MiB which would be 
+10,485,760 bytes.
+
 A previous draft of BIP270 required scripts be formatted as a human-readable "isomorphic"
 ASM-formatted string, to simplify debugging.  However ASM is a UI concept; it is best left
 to user-facing software to decide how display scripts readably rather than enshrining it


### PR DESCRIPTION
…it makes a difference which is used, as long as is clear.