### PR TITLE
transaction -> transactions

### DIFF
--- a/bip-0270.mediawiki
+++ b/bip-0270.mediawiki
@@ -176,7 +176,7 @@ Payment {
 {|
 | merchantData || copied from PaymentDetails.merchantData. Payment hosts may use invoice numbers or any other data they require to match Payments to  PaymentRequests. Note that malicious clients may modify the merchantData, so should be authenticated in some way (for example, signed with a payment host-only key).
 |-
-| transaction || A valid, signed Bitcoin transaction that fully pays the PaymentRequest. The transaction is hex-encoded and must NOT be prefixed with "0x".
+| transactions || An array of valid, signed Bitcoin transactions that fully pays the PaymentRequest. The transactions are hex-encoded and must NOT be prefixed with "0x".
 |-
 | refundTo || One or more outputs where the payment host may return funds, if necessary. The payment host may return funds using these outputs for up to 2 months
 after the time of the payment request. After that time has expired, parties must negotiate if returning of funds becomes necessary.
@@ -185,10 +185,10 @@ after the time of the payment request. After that time has expired, parties must
 |}
 If the customer authorizes payment, then the Bitcoin client:
 
-# Creates and signs a transaction that satisfy (pay in full) PaymentDetails.outputs
+# Creates and signs a transaction(s) that satisfy (pay in full) PaymentDetails.outputs
 # Validate that customer's system unix time (UTC) is still before PaymentDetails.expirationTimestamp. If it is not, the payment should be cancelled.
 # A POST a Payment message to the paymentUrl URL. The Payment message is serialized and sent as the body of the POST request.
-# The client can optionall broadcast the transaction(s) themselves to the Bitcoin network, but they are not required to do so as the payment host is expected to do so. If the payment host never broadcasts the transaction, then after two months the client can recover their funds.
+# The client can optionally broadcast the transaction(s) themselves to the Bitcoin network, but they are not required to do so as the payment host is expected to do so. If the payment host never broadcasts the transaction(s), then after two months the client can recover their funds.
 
 Errors communicating with the paymentUrl server should be communicated to the user.
 In the scenario where the payment host's server receives multiple identical Payment


### PR DESCRIPTION
Like the original BIP 70.

Note that, in practice, we do not expect most wallets to support multiple transactions at launch. Instead, they will regard as invalid any list of transactions.