### PR TITLE
Clarification about leftover change

### DIFF
--- a/bip-0270.mediawiki
+++ b/bip-0270.mediawiki
@@ -184,7 +184,7 @@ Payment {
 |}
 If the customer authorizes payment, then the Bitcoin client:
 
-# Creates and signs a transaction that satisfy (pay in full) PaymentDetails.outputs
+# Creates and signs a transaction that satisfy (pay in full) PaymentDetails.outputs. It may add additional outputs to get the change from any overpaying inputs, if needed.
 # Validate that customer's system unix time (UTC) is still before PaymentDetails.expirationTimestamp. If it is not, the payment should be cancelled.
 # A POST a Payment message to the paymentUrl URL. The Payment message is serialized and sent as the body of the POST request.
 # The client can optionally broadcast the transaction themselves to the Bitcoin network, but they are not required to do so as the payment host is expected to do so. If the payment host never broadcasts the transaction, then after two months the client can recover their funds.


### PR DESCRIPTION
Added clarification about creating extra outputs and not just the ones requested.

// Just clarifying that having more outputs than the requested ones is OK.
// ...It is OK, isn't it?